### PR TITLE
Hw2 grep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,3 +24,9 @@ compileKotlin {
 compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'ru.spb.hse.karvozavr.cli.Main'
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    compile "com.xenomachina:kotlin-argparser:2.0.7"
     testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'
     testCompile group: 'junit', name: 'junit-dep', version: '4.10'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/CommandFactory.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/CommandFactory.kt
@@ -34,7 +34,7 @@ object CommandFactory {
     ): Command = when (commandName) {
         "cat" -> CatCommand(args, inStream, outStream, errStream, shell)
         "echo" -> EchoCommand(args, inStream, outStream, errStream, shell)
-        "wc" -> WordcountCommand(args, inStream, outStream, errStream, shell)
+        "wc" -> WordCountCommand(args, inStream, outStream, errStream, shell)
         "pwd" -> PwdCommand(args, inStream, outStream, errStream, shell)
         "exit" -> ExitCommand(args, inStream, outStream, errStream, shell)
         "grep" -> GrepCommand(args, inStream, outStream, errStream, shell)

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/CommandFactory.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/CommandFactory.kt
@@ -37,6 +37,7 @@ object CommandFactory {
         "wc" -> WordcountCommand(args, inStream, outStream, errStream, shell)
         "pwd" -> PwdCommand(args, inStream, outStream, errStream, shell)
         "exit" -> ExitCommand(args, inStream, outStream, errStream, shell)
+        "grep" -> GrepCommand(args, inStream, outStream, errStream, shell)
         "=" -> AssignmentCommand(args, inStream, outStream, errStream, shell)
         else -> ExternalCommand(
             args,

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/ExternalCommand.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/ExternalCommand.kt
@@ -25,6 +25,11 @@ class ExternalCommand(
     private val inFile = Files.createTempFile("pipetempin", ".tmp")
     private val outFile = Files.createTempFile("pipetempout", ".tmp")
 
+    init {
+        inFile.toFile().deleteOnExit()
+        outFile.toFile().deleteOnExit()
+    }
+
     override fun execute(): ExitCode {
         return try {
             val commandList = listOf(command) + args

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/GrepCommand.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/GrepCommand.kt
@@ -1,2 +1,81 @@
 package ru.spb.hse.karvozavr.cli.commands.builtins
 
+import ru.spb.hse.karvozavr.cli.commands.Command
+import ru.spb.hse.karvozavr.cli.shell.Shell
+import ru.spb.hse.karvozavr.cli.streams.InStream
+import ru.spb.hse.karvozavr.cli.streams.OutStream
+import ru.spb.hse.karvozavr.cli.util.ExitCode
+import com.xenomachina.argparser.ArgParser
+import com.xenomachina.argparser.default
+import kotlin.system.exitProcess
+
+/**
+ * Find pattern in input stream.
+ */
+class GrepCommand(
+    args: List<String>,
+    inputStream: InStream,
+    outStream: OutStream,
+    errStream: OutStream,
+    shell: Shell
+) : Command(args, inputStream, outStream, errStream, shell) {
+
+    private class GrepArgs(parser: ArgParser) {
+        val caseInsensitive by parser.flagging(
+            "-i",
+            help = "search case-insensitive"
+        )
+
+        val word by parser.flagging(
+            "-w",
+            help = "look for the whole word match"
+        )
+
+        val reg by parser.flagging(
+            "-e",
+            help = "interpret pattern as regex"
+        )
+
+        val count by parser.storing(
+            "-A",
+            help = "print n lines after match"
+        ) { toInt() }.default(0)
+
+        val pattern by parser.positional(
+            "PATTERN",
+            help = "pattern to search for"
+        )
+    }
+
+    override fun execute(): ExitCode {
+        try {
+            ArgParser(args = args.toTypedArray()).parseInto(::GrepArgs).run {
+                val pattern = if (word) "(\\s+|^)$pattern(\\s+|$)" else pattern
+                val options = mutableSetOf<RegexOption>()
+                if (!reg)
+                    options.add(RegexOption.LITERAL)
+                if (caseInsensitive)
+                    options.add(RegexOption.IGNORE_CASE)
+
+                val r = pattern.toRegex(options)
+
+                var printLines = 0
+
+                while (inputStream.isNotEmpty()) {
+                    val line = inputStream.scanLine()
+                    if (r.containsMatchIn(line)) {
+                        writeLine(line)
+                        printLines = count
+                    } else if (printLines > 0) {
+                        writeLine(line)
+                        --printLines
+                    }
+                }
+            }
+        } catch (e: Throwable) {
+            return ExitCode.INVALID_ARGUMENTS
+        }
+
+        return ExitCode.SUCCESS
+    }
+}

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/GrepCommand.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/GrepCommand.kt
@@ -31,11 +31,6 @@ class GrepCommand(
             help = "look for the whole word match"
         )
 
-        val reg by parser.flagging(
-            "-e",
-            help = "interpret pattern as regex"
-        )
-
         val count by parser.storing(
             "-A",
             help = "print n lines after match"
@@ -52,8 +47,7 @@ class GrepCommand(
             ArgParser(args = args.toTypedArray()).parseInto(::GrepArgs).run {
                 val pattern = if (word) "(\\s+|^)$pattern(\\s+|$)" else pattern
                 val options = mutableSetOf<RegexOption>()
-                if (!reg)
-                    options.add(RegexOption.LITERAL)
+
                 if (caseInsensitive)
                     options.add(RegexOption.IGNORE_CASE)
 

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/GrepCommand.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/GrepCommand.kt
@@ -1,0 +1,2 @@
+package ru.spb.hse.karvozavr.cli.commands.builtins
+

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/WordCountCommand.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/WordCountCommand.kt
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 /**
  * Wordcount command.
  */
-class WordcountCommand(
+class WordCountCommand(
     args: List<String>,
     inputStream: InStream,
     outStream: OutStream,

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/parser/CommandNode.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/parser/CommandNode.kt
@@ -1,3 +1,6 @@
 package ru.spb.hse.karvozavr.cli.parser
 
+/**
+ * Parsed command AST node.
+ */
 data class CommandNode(val name: String, val args: List<String>)

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/parser/CommandParser.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/parser/CommandParser.kt
@@ -2,10 +2,19 @@ package ru.spb.hse.karvozavr.cli.parser
 
 import ru.spb.hse.karvozavr.cli.shell.env.Environment
 
+/**
+ * Parser exception.
+ */
 class ParseException(err: String) : RuntimeException(err)
 
+/**
+ * Parser for shell commands.
+ */
 object CommandParser {
 
+    /**
+     * Parses command with interpolation in context of given environment.
+     */
     fun parse(command: String, env: Environment): List<CommandNode> =
         createPipeline(collapseTokens(interpolateTokens(tokenize(command), env)))
 

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/parser/CommandParser.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/parser/CommandParser.kt
@@ -103,6 +103,8 @@ object CommandParser {
                 } else if (weakQuoting) {
                     stringBuilder.append(c)
                 } else {
+                    tokens.add(InterpolationToken(stringBuilder.toString()))
+                    stringBuilder.clear()
                     strongQuoting = true
                 }
                 '\"' -> if (weakQuoting) {
@@ -112,6 +114,8 @@ object CommandParser {
                 } else if (strongQuoting) {
                     stringBuilder.append(c)
                 } else {
+                    tokens.add(InterpolationToken(stringBuilder.toString()))
+                    stringBuilder.clear()
                     weakQuoting = true
                 }
                 '=' -> {

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/parser/Token.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/parser/Token.kt
@@ -3,10 +3,20 @@ package ru.spb.hse.karvozavr.cli.parser
 import ru.spb.hse.karvozavr.cli.shell.env.Environment
 import java.lang.StringBuilder
 
+/**
+ * Lexer token.
+ */
 sealed class Token(val token: String) {
+
+    /**
+     * Interpolate this token in context of given environment.
+     */
     abstract fun interpolate(env: Environment): Token
 }
 
+/**
+ * Token which require interpolation.
+ */
 class InterpolationToken(token: String) : Token(token) {
     override fun interpolate(env: Environment): NoInterpolationToken {
         val r: Regex = Regex("[$]([A-Za-z0-9_]+|[?])")
@@ -29,16 +39,31 @@ class InterpolationToken(token: String) : Token(token) {
     }
 }
 
+/**
+ * Token which doesn't require interpolation.
+ */
 sealed class NoInterpolationToken(token: String) : Token(token) {
     override fun interpolate(env: Environment): NoInterpolationToken {
         return this
     }
 }
 
+/**
+ * Pipe token.
+ */
 object PipeToken : NoInterpolationToken("|")
 
+/**
+ * Whitespace token.
+ */
 object WhitespaceToken : NoInterpolationToken(" ")
 
+/**
+ * Assignment token.
+ */
 object AssignmentToken : NoInterpolationToken("=")
 
+/**
+ * Value token.
+ */
 class ValueToken(token: String) : NoInterpolationToken(token)

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/shell/env/CliEnvironment.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/shell/env/CliEnvironment.kt
@@ -18,7 +18,7 @@ class CliEnvironment(
         currentDir
 
     override fun changeDirectory(newDir: Path) {
-        currentDir = Paths.get(newDir.toString())
+        currentDir = newDir
     }
 
     override fun shellPrompt(): String {

--- a/src/main/kotlin/ru/spb/hse/karvozavr/cli/shell/env/Environment.kt
+++ b/src/main/kotlin/ru/spb/hse/karvozavr/cli/shell/env/Environment.kt
@@ -35,4 +35,3 @@ interface Environment {
      */
     fun shellPrompt(): String
 }
-

--- a/src/test/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/GrepCommandTest.kt
+++ b/src/test/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/GrepCommandTest.kt
@@ -1,0 +1,81 @@
+package ru.spb.hse.karvozavr.cli.commands.builtins
+
+import org.junit.Test
+
+import org.junit.Assert.*
+import ru.spb.hse.karvozavr.cli.shell.CliShell
+import ru.spb.hse.karvozavr.cli.streams.ReadWriteStream
+import ru.spb.hse.karvozavr.cli.util.ExitCode
+
+class GrepCommandTest {
+
+    @Test
+    fun testSimple() {
+        val inStream = ReadWriteStream()
+        val errStream = ReadWriteStream()
+        val inputData = listOf("big brown Fox", "jumps over", "the lazy fox")
+        inputData.forEach { inStream.write(it) }
+        val outStream = ReadWriteStream()
+
+        val cmd = GrepCommand(listOf("fox"), inStream, outStream, errStream, CliShell.emptyShell())
+
+        assertEquals(ExitCode.SUCCESS, cmd.execute())
+        assertEquals(true, outStream.isNotEmpty())
+        assertEquals(true, errStream.isEmpty())
+
+        val seq = generateSequence { if (outStream.isNotEmpty()) outStream.scanLine() else null }
+        assertEquals(listOf("big brown Fox"), seq.toList())
+        assertEquals(true, outStream.isEmpty())
+    }
+
+    @Test
+    fun testEmptyArgs() {
+        val inStream = ReadWriteStream()
+        val errStream = ReadWriteStream()
+        val inputData = listOf("big brown fox", "jumps over", "the lazy fox")
+        inputData.forEach { inStream.write(it) }
+        val outStream = ReadWriteStream()
+
+        val cmd = GrepCommand(listOf(), inStream, outStream, errStream, CliShell.emptyShell())
+
+        assertEquals(ExitCode.INVALID_ARGUMENTS, cmd.execute())
+    }
+
+    @Test
+    fun testIgnoreCase() {
+        val inStream = ReadWriteStream()
+        val errStream = ReadWriteStream()
+        val inputData = listOf("big brown Fox", "jumps over", "the lazy fox")
+        inputData.forEach { inStream.write(it) }
+        val outStream = ReadWriteStream()
+
+        val cmd = GrepCommand(listOf("fox", "-i"), inStream, outStream, errStream, CliShell.emptyShell())
+
+        assertEquals(ExitCode.SUCCESS, cmd.execute())
+        assertEquals(true, outStream.isNotEmpty())
+        assertEquals(true, errStream.isEmpty())
+
+        val seq = generateSequence { if (outStream.isNotEmpty()) outStream.scanLine() else null }
+        assertEquals(listOf("big brown Fox", "the lazy fox"), seq.toList())
+        assertEquals(true, outStream.isEmpty())
+    }
+
+    @Test
+    fun testWord() {
+        val inStream = ReadWriteStream()
+        val errStream = ReadWriteStream()
+        val inputData = listOf("big brown fox", "jumps over", "the lazy fox-terrier")
+        inputData.forEach { inStream.write(it) }
+        val outStream = ReadWriteStream()
+
+        val cmd = GrepCommand(listOf("fox", "-w"), inStream, outStream, errStream, CliShell.emptyShell())
+
+        assertEquals(ExitCode.SUCCESS, cmd.execute())
+        assertEquals(true, outStream.isNotEmpty())
+        assertEquals(true, errStream.isEmpty())
+
+        val seq = generateSequence { if (outStream.isNotEmpty()) outStream.scanLine() else null }
+        assertEquals(listOf("big brown Fox"), seq.toList())
+        assertEquals(true, outStream.isEmpty())
+    }
+}

--- a/src/test/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/GrepCommandTest.kt
+++ b/src/test/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/GrepCommandTest.kt
@@ -24,7 +24,7 @@ class GrepCommandTest {
         assertEquals(true, errStream.isEmpty())
 
         val seq = generateSequence { if (outStream.isNotEmpty()) outStream.scanLine() else null }
-        assertEquals(listOf("big brown Fox"), seq.toList())
+        assertEquals(listOf("the lazy fox"), seq.toList())
         assertEquals(true, outStream.isEmpty())
     }
 
@@ -75,7 +75,26 @@ class GrepCommandTest {
         assertEquals(true, errStream.isEmpty())
 
         val seq = generateSequence { if (outStream.isNotEmpty()) outStream.scanLine() else null }
-        assertEquals(listOf("big brown Fox"), seq.toList())
+        assertEquals(listOf("big brown fox"), seq.toList())
+        assertEquals(true, outStream.isEmpty())
+    }
+
+    @Test
+    fun testNLines() {
+        val inStream = ReadWriteStream()
+        val errStream = ReadWriteStream()
+        val inputData = listOf("big brown Fox", "jumps over the fence", "the lazy fox-terrier", "really lazy", "one")
+        inputData.forEach { inStream.write(it) }
+        val outStream = ReadWriteStream()
+
+        val cmd = GrepCommand(listOf("fence", "-A", "2"), inStream, outStream, errStream, CliShell.emptyShell())
+
+        assertEquals(ExitCode.SUCCESS, cmd.execute())
+        assertEquals(true, outStream.isNotEmpty())
+        assertEquals(true, errStream.isEmpty())
+
+        val seq = generateSequence { if (outStream.isNotEmpty()) outStream.scanLine() else null }
+        assertEquals(listOf("jumps over the fence", "the lazy fox-terrier", "really lazy"), seq.toList())
         assertEquals(true, outStream.isEmpty())
     }
 }

--- a/src/test/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/WordCountCommandTest.kt
+++ b/src/test/kotlin/ru/spb/hse/karvozavr/cli/commands/builtins/WordCountCommandTest.kt
@@ -8,7 +8,7 @@ import ru.spb.hse.karvozavr.cli.streams.ReadWriteStream
 import ru.spb.hse.karvozavr.cli.util.ExitCode
 import java.nio.file.Paths
 
-class WordcountCommandTest {
+class WordCountCommandTest {
 
     private val testDirecory = Paths.get("src", "test", "resources").toAbsolutePath()
     private val file1 = (testDirecory.resolve("file1.txt")).toString()
@@ -19,7 +19,7 @@ class WordcountCommandTest {
         val errStream = ReadWriteStream()
         val outStream = ReadWriteStream()
 
-        val cmd = WordcountCommand(listOf(emptyFile), EmptyStream, outStream, errStream, CliShell.emptyShell())
+        val cmd = WordCountCommand(listOf(emptyFile), EmptyStream, outStream, errStream, CliShell.emptyShell())
 
         assertEquals(ExitCode.SUCCESS, cmd.execute())
         assertEquals(true, outStream.isNotEmpty())
@@ -33,7 +33,7 @@ class WordcountCommandTest {
         val errStream = ReadWriteStream()
         val outStream = ReadWriteStream()
 
-        val cmd = WordcountCommand(listOf(file1), EmptyStream, outStream, errStream, CliShell.emptyShell())
+        val cmd = WordCountCommand(listOf(file1), EmptyStream, outStream, errStream, CliShell.emptyShell())
 
         assertEquals(ExitCode.SUCCESS, cmd.execute())
         assertEquals(true, outStream.isNotEmpty())

--- a/src/test/kotlin/ru/spb/hse/karvozavr/cli/parser/CommandParserTest.kt
+++ b/src/test/kotlin/ru/spb/hse/karvozavr/cli/parser/CommandParserTest.kt
@@ -3,8 +3,15 @@ package ru.spb.hse.karvozavr.cli.parser
 import org.junit.Test
 
 import org.junit.Assert.*
+import ru.spb.hse.karvozavr.cli.pipeline.Pipeline
+import ru.spb.hse.karvozavr.cli.pipeline.PipelineFactory
 import ru.spb.hse.karvozavr.cli.shell.CliShell
 import ru.spb.hse.karvozavr.cli.shell.env.CliEnvironment
+import ru.spb.hse.karvozavr.cli.streams.EmptyStream
+import ru.spb.hse.karvozavr.cli.streams.ReadWriteStream
+import ru.spb.hse.karvozavr.cli.util.ExitCode
+import java.nio.file.Files
+import java.nio.file.Paths
 
 class CommandParserTest {
 
@@ -84,10 +91,24 @@ class CommandParserTest {
         val cmd = "echo b\$a \$bbb\$ccc r | cat | echo \$a\$c \'\$ccc\' | cat"
         val parsedValue = CommandParser.parse(cmd, env)
         assertArrayEquals(
-            arrayOf(CommandNode("echo", listOf("bbaz", "bc", "r")),
+            arrayOf(
+                CommandNode("echo", listOf("bbaz", "bc", "r")),
                 CommandNode("cat", listOf()),
                 CommandNode("echo", listOf("baz", "\$ccc")),
-                CommandNode("cat", listOf())),
+                CommandNode("cat", listOf())
+            ),
+            parsedValue.toTypedArray()
+        )
+        println(parsedValue)
+    }
+
+    @Test
+    fun testInterpolationBeforeStrongQuoting() {
+        val env = CliEnvironment(mutableMapOf("t" to "test"))
+        val cmd = "echo \$t'\$t'"
+        val parsedValue = CommandParser.parse(cmd, env)
+        assertArrayEquals(
+            arrayOf(CommandNode("echo", listOf("test\$t"))),
             parsedValue.toTypedArray()
         )
         println(parsedValue)


### PR DESCRIPTION
Почему для аргументов использован xenomachina.argparse:

Я искал библиотеку именно для Kotlin, а не на Java, чтобы null-ы не лезли из всех щелей.
Для Kotlin методом plain old googling нашел 3 библиотеки:
- Clikt перехватывает на себя не только парсинг, но и права функции main - по сути cli фреймворк - не подходит
- kotlinx.cli отсутствует в репозиториях, добавлять исходник к сборке не хочется, чтобы не засорять проект 
- xenomachina.argparse есть в репозиториях, выполняет только задачу парсинга, как и требовалось - наш выбор
